### PR TITLE
Find or build rapids-4-spark-private jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -641,6 +641,7 @@
           </activation>
           <properties>
             <buildver>351odp</buildver>
+            <spark.version.classifier>spark351odp</spark.version.classifier>
             <spark.version>${spark351odp.version}</spark.version>
             <spark.test.version>${spark351odp.version}</spark.test.version>
             <parquet.hadoop.version>1.13.1</parquet.hadoop.version>


### PR DESCRIPTION
<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Please read https://github.com/NVIDIA/spark-rapids/blob/HEAD/CONTRIBUTING.md#creating-a-pull-request before making this PR.

The following are the guidelines to help the review process go smoothly. Please read them carefully and fill out relevant information as much as possible.

Thank you for your cooperation!

-->

<!--
Please replace #xxxx with the ID of the issue fixed in this PR. If such issue does not exist, please consider filing one and link it here.
-->
Fixes #xxxx.

### Description

<!--
Please provide a description of the changes proposed in this pull request. Here are some questions to help you fill out the description:

- What is the problem you are trying to solve? Describe it from the user's perspective. If you have an existing github issue, please add a summary of the issue here.
- After this change, what will the user experience be like? Please describe any user-facing changes, such as new configurations or new behaviors. If you are introducing new configurations, please add some guidelines on how to use them.
- How are you fixing the problem? Please provide a technical description of your solution. You can add or link your design doc if it exists.
- How are the new features/behaviors tested? Please describe the test cases you added or modified. If they are tested in a cluster, please describe it as well.
-->
The `release351odp` Maven profile was unable to correctly resolve the `rapids-4-spark-private` JAR with the `351odp` classifier, leading to build failures or incorrect dependency resolution when building against a custom Spark version.

This change adds the missing `spark.version.classifier` property to the `release351odp` profile in `pom.xml`. After this change, users building with `-Prelease351odp` will have the `rapids-4-spark-private` dependency correctly resolved with the `spark351odp` classifier, aligning its behavior with other custom Spark profiles.

### Checklists

<!-- 
Check the items below by putting "x" in the brackets for what is done.
Not all of these items may be relevant to every PR, so please check only those that apply.
-->

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6f0c4c2-c6ab-49bc-babe-9f934e97bfce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6f0c4c2-c6ab-49bc-babe-9f934e97bfce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

