### PR TITLE
ODP-7149: Use NullOutputStream.INSTANCE for 333odp shim

### DIFF
--- a/sql-plugin/src/main/spark333odp/scala/com/nvidia/spark/rapids/shims/NullOutputStreamShim.scala
+++ b/sql-plugin/src/main/spark333odp/scala/com/nvidia/spark/rapids/shims/NullOutputStreamShim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,32 +15,12 @@
  */
 
 /*** spark-rapids-shim-json-lines
-{"spark": "320"}
-{"spark": "321"}
-{"spark": "321cdh"}
-{"spark": "322"}
-{"spark": "323"}
-{"spark": "324"}
-{"spark": "330"}
-{"spark": "330cdh"}
-{"spark": "330db"}
-{"spark": "331"}
-{"spark": "332"}
-{"spark": "332cdh"}
-{"spark": "332db"}
-{"spark": "333"}
-{"spark": "334"}
-{"spark": "340"}
-{"spark": "341"}
-{"spark": "341db"}
-{"spark": "342"}
-{"spark": "343"}
-{"spark": "344"}
+{"spark": "333odp"}
 spark-rapids-shim-json-lines ***/
 package com.nvidia.spark.rapids.shims
 
 import org.apache.commons.io.output.NullOutputStream
 
 object NullOutputStreamShim {
-  def INSTANCE = NullOutputStream.NULL_OUTPUT_STREAM
+  def INSTANCE = NullOutputStream.INSTANCE
 }


### PR DESCRIPTION
ODP Spark 3.3.3 ships commons-io >= 2.12 where NULL_OUTPUT_STREAM is deprecated and fails the build.

